### PR TITLE
removed beaconByManager for /device resource

### DIFF
--- a/lib/kontakt.js
+++ b/lib/kontakt.js
@@ -4,7 +4,8 @@ var request = require('request');
 //set up the users API key
 function KontaktApi(key) {
   this.key = key !== null ? key : null;
-  this.beacon_endpoint = 'beacon/';
+  this.beacon_endpoint = 'beacon/'; //temp to support deprecated resource
+  this.device_endpoint = 'device/';
   var self = this instanceof KontaktApi ? this : Object.create(KontaktApi.prototype);
 }
 
@@ -49,7 +50,7 @@ KontaktApi.prototype.beaconById = function (params, callback) {
   if ((params !== null) && typeof params === 'object') {
 
     if (Array.isArray(params.beaconId) === false) {
-      var path = base_url + '/' + this.beacon_endpoint + params.beaconId;
+      var path = base_url + '/' + this.device_endpoint + params.beaconId;
       return this.getBeacon(path, callback);
     } else {
       callback(null, 'ERROR: only request one beacon at a time');
@@ -61,20 +62,8 @@ KontaktApi.prototype.beaconById = function (params, callback) {
 };
 
 /**
- * deprecated - use /device instead
- */
-KontaktApi.prototype.beaconByManager = function (params, callback) {
-  if ((params !== null) && typeof params === 'object') {
-    var path = base_url + this.beacon_endpoint + '?managerId=' + params.managerId;
-    return this.getBeacon(path, callback);
-  } else {
-    callback(null, 'Invalid Setting: please provide an object');
-  }
-};
-
-/**
- * /beacon by proximity
- */
+* /beacon by proximity
+*/
 KontaktApi.prototype.beaconByProximity = function (params, callback) {
   if ((params !== null) && typeof params === 'object') {
     var path = base_url + this.beacon_endpoint + params.proximity +'/' + params.major + '/' + params.minor;
@@ -85,8 +74,8 @@ KontaktApi.prototype.beaconByProximity = function (params, callback) {
 };
 
 /**
- * /beacon by credentials
- */
+* /beacon by credentials
+*/
 KontaktApi.prototype.beaconCredentials = function (params, callback) {
   if ((params !== null) && typeof params === 'object') {
 
@@ -103,11 +92,15 @@ KontaktApi.prototype.beaconCredentials = function (params, callback) {
 };
 
 /**
- * lists all devices
- */
+* lists all devices
+*/
 KontaktApi.prototype.device = function (params, callback) {
+  var path = base_url + this.device_endpoint;
+  if (arguments.length === 1) {
+    var callback = params;
+    return this.getBeacon(path, callback);
+  }
   if ((params !== null) && typeof params === 'object') {
-    var path = base_url + 'device';
     return this.getBeacon(path, callback);
   } else {
     callback(null, 'Invalid Setting: please provide an object');


### PR DESCRIPTION
/beacon resource has been deprecated. Start adding /device resource to
take it’s place.
